### PR TITLE
Fix #12202

### DIFF
--- a/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
+++ b/app/code/Magento/Customer/view/frontend/templates/address/edit.phtml
@@ -46,7 +46,7 @@
             </label>
             <div class="control">
                 <input type="text"
-                       name="street[]"
+                       name="street[<?php echo $_i;?>]"
                        value="<?= $block->escapeHtmlAttr($block->getStreetLine(1)) ?>"
                        title="<?= $block->escapeHtmlAttr(__('Street Address')) ?>"
                        id="street_1"
@@ -59,7 +59,7 @@
                                 <span><?= $block->escapeHtml(__('Street Address %1', $_i + 1)) ?></span>
                             </label>
                             <div class="control">
-                                <input type="text" name="street[]"
+                                <input type="text" name="street[<?php echo $_i;?>]"
                                        value="<?= $block->escapeHtmlAttr($block->getStreetLine($_i + 1)) ?>"
                                        title="<?= $block->escapeHtmlAttr(__('Street Address %1', $_i + 1)) ?>"
                                        id="street_<?= /* @noEscape */ $_i + 1 ?>"


### PR DESCRIPTION
Fix the issue #12202

### Description
add unique name for additional address fields

### Fixed Issues 
1. magento/magento2#12202: M2.1.9 : Cannot make all address fields required in customer address edit page (frontend)

### Manual testing scenarios
1.add required class for additional address fields
2. test it on address edit page

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
